### PR TITLE
Update manage command to only nuke Docker containers initiated by Clusterdock-initiated containers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,32 @@ target/
 
 # pyenv python configuration file
 .python-version
+# OS X
+.DS_Store
+
+# vim
+*.swp
+
+__status__
+
+# 3.6 Virtual env stuff
+bin/
+include/
+share/
+*.egg-info
+pip-selfcheck.json
+pyvenv.cfg
+
+# Caching
+__pycache__
+
+
+pip-delete-*
+
+# Unit tests / coverage reports
+
+
+# Django
+
+
+# Pybuilder

--- a/clusterdock/actions/manage.py
+++ b/clusterdock/actions/manage.py
@@ -26,12 +26,13 @@ def main(args):
 
     if args.manage_action == 'nuke':
         if client.containers.list():
-            logger.info('Stopping and removing all containers ...')
+            logger.info('Stopping and removing all Clusterdock-initiated containers ...')
             for container in client.containers.list(all=True):
-                logger.debug('Removing container %s ...',
-                             container.id)
-                if not args.dry_run:
-                    container.remove(v=True, force=True)
+                if any('clusterdock' in n for n in container.image.attrs['RepoTags']):
+                    logger.debug('Removing container %s ...',
+                                 container.id)
+                    if not args.dry_run:
+                        container.remove(v=True, force=True)
         else:
             logger.warning("Didn't find any containers to remove. Continuing ...")
 


### PR DESCRIPTION
Patch will change the ```clusterdock manage nuke``` command to only remove Docker containers that were initiated by Clusterdock (specifically, have ```clusterdock``` in the image tag).