### PR TITLE
Pin docker-py version to avoid upstream changes that might impact Clusterdock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@
 # limitations under the License.
 
 colorlog
-docker==2.4.2
+docker==4.2.2
 PyYAML
 pytest==3.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,7 @@
 bumpversion==0.5.3
 coverage==4.1
 cryptography==1.7
-docker==2.4.2
+docker==4.2.2
 flake8==2.6.0
 PyYAML
 pip==8.1.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'colorlog',
-    'docker',
+    'docker==4.2.2',
     'PyYAML',
     'python-dateutil',
 ]


### PR DESCRIPTION
Avoids for example issues like: https://github.com/docker/docker-py/issues/2639